### PR TITLE
Fix env file typo and add MySQL setup instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,10 @@
 #   rbenv exec bundle install
 #   rbenv exec bundle exec rails server -b 0.0.0.0
 #
+# If you need to connect to MySQL, start MySQL on the host OS with the following command:
+#
+#   docker run --rm --name some-mysql -e MYSQL_ROOT_PASSWORD=password -p 3306:3306 -d mysql:8.0.45
+#
 
 # Debian 12.13
 FROM debian:bookworm-20260202

--- a/env
+++ b/env
@@ -1,5 +1,3 @@
-LANG
-
 MYSQL_USER="root"
 MYSQL_PASSWORD="password"
 MYSQL_HOST="host.docker.internal"

--- a/env
+++ b/env
@@ -1,6 +1,6 @@
 LANG
 
 MYSQL_USER="root"
-MYSQL_PASSWOWRD="password"
+MYSQL_PASSWORD="password"
 MYSQL_HOST="host.docker.internal"
 DATABASE="hello_rails_development"


### PR DESCRIPTION
## Summary
- Fix typo in env file: `MYSQL_PASSWOWRD` -> `MYSQL_PASSWORD`
- Remove unnecessary `LANG` entry from env file to use Dockerfile's `C.UTF-8` default
- Add MySQL container startup instructions to Dockerfile comments

## Test plan
- [ ] Verify the env file has the correct `MYSQL_PASSWORD` variable name
- [ ] Confirm Rails can connect to MySQL using the corrected env variables
- [ ] Check that Dockerfile comments accurately describe MySQL container setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)