### PR TITLE
Add RuboCop GitHub Actions workflow

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -1,0 +1,40 @@
+name: RuboCop
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+    paths:
+      - '**/*.rb'
+      - '**/*.rake'
+      - 'Gemfile'
+      - 'Gemfile.lock'
+      - '.rubocop.yml'
+      - '.rubocop_todo.yml'
+      - '.github/workflows/rubocop.yml'
+  pull_request:
+    paths:
+      - '**/*.rb'
+      - '**/*.rake'
+      - 'Gemfile'
+      - 'Gemfile.lock'
+      - '.rubocop.yml'
+      - '.rubocop_todo.yml'
+      - '.github/workflows/rubocop.yml'
+
+jobs:
+  rubocop:
+    name: Lint Ruby
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Run RuboCop
+        run: bundle exec rubocop

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -33,8 +33,9 @@ jobs:
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
-        with:
-          bundler-cache: true
+
+      - name: Install dependencies
+        run: bundle install
 
       - name: Run RuboCop
         run: bundle exec rubocop

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,7 @@
 plugins:
   - rubocop-rails
   - rubocop-rspec
+  - rubocop-performance
 
 AllCops:
   TargetRubyVersion: 3.3.10

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,6 +132,8 @@ GEM
     nio4r (2.7.5)
     nokogiri (1.19.1-aarch64-linux-gnu)
       racc (~> 1.4)
+    nokogiri (1.19.1-x86_64-linux-gnu)
+      racc (~> 1.4)
     parallel (1.27.0)
     parser (3.3.10.2)
       ast (~> 2.4.1)
@@ -249,6 +251,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   debug


### PR DESCRIPTION
## Summary
- RuboCop を GitHub Actions で自動実行するワークフローを追加
- `.rubocop.yml` に未登録だった `rubocop-performance` プラグインを追加
- `Gemfile.lock` に CI ランナー用の `x86_64-linux` プラットフォームを追加

## Changes
- `.github/workflows/rubocop.yml`: 新規作成。push (main/develop) および PR 時に Ruby 関連ファイルの変更を検知して `bundle exec rubocop` を実行
- `.rubocop.yml`: `rubocop-performance` プラグインを追加
- `Gemfile.lock`: `x86_64-linux` プラットフォームを追加

## Test plan
- [ ] GitHub Actions の RuboCop ジョブが正常に実行されることを確認
- [ ] Ruby 関連ファイル以外の変更ではワークフローがスキップされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)