### PR TITLE
Add wiki link comment for ignored Hadolint rule DL3003

### DIFF
--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,2 +1,4 @@
 ignored:
+  # Use WORKDIR to switch to a directory
+  # https://github.com/hadolint/hadolint/wiki/DL3003
   - DL3003


### PR DESCRIPTION
## Summary
- `.hadolint.yaml` で無視しているルール DL3003 に、ルールの説明とHadolint wikiページへのリンクをコメントとして追加

## Test plan
- [ ] Hadolint CIが正常に通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)