### PR TITLE
Add explicit GitHub Actions schema mapping for YAML extension

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,6 +6,9 @@
     "identifier": "rbenv"
   },
   "rubyLsp.formatter": "rubocop",
+  "yaml.schemas": {
+    "https://json.schemastore.org/github-workflow.json": ".github/workflows/*.yml"
+  },
   // https://shopify.github.io/ruby-lsp/RubyLsp/Requests.html
   "rubyLsp.enabledFeatures": {
     "codeActions": true,


### PR DESCRIPTION
## Summary
- `.vscode/settings.json` に `yaml.schemas` を追加し、`.github/workflows/*.yml` に GitHub Actions スキーマを明示的にマッピング
- `redhat.vscode-yaml` と `GitHub.vscode-github-actions` の競合により、ワークフローファイルで "Property name is not allowed." バリデーションエラーが発生していた問題を解消

## Test plan
- [ ] VS Code でワークフローファイル (`.github/workflows/*.yml`) を開き、"Property name is not allowed." エラーが表示されないことを確認
- [ ] ワークフローファイルで GitHub Actions スキーマによる補完・バリデーションが正しく動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)